### PR TITLE
Update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
 #SBATCH --job-name="RPCA"
-#SBATCH --mem=50g
-#SBATCH --ntasks-per-node=10
+#SBATCH --mem=5g
 #SBATCH --time=8:0:0
 #SBATCH --partition=all,highmem
 #SBATCH --output=RPCA-%j.out


### PR DESCRIPTION
Submitting the pipeline script itself, instead of running it directly on the headnode, is not necessary but also not a bad practice. I do not, however, see necessity in the 50 GB (--mem=50g) of resources for this script. This is only calculating the job graph and submitting jobs to the cluster. For the same reason, the --ntasks-per-node=10 is not needed