### PR TITLE
Update Snakefile

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -27,13 +27,15 @@ rule all:
 rule minimap2_align:
     input:
         genome = genome_fasta,
-        fq = READSDIR / "{sample}"
+        fq = READSDIR + "/{sample}"
     params:
         outdir = OUTDIR,
         opts = config["minimap2_opts"]
     output:
-        sam_files = OUTDIR / "{sample}.sam"
+        sam_files = OUTDIR + "/{sample}.sam"
     threads: 4
+    resources:
+        mem=10G
     singularity:
         'docker://quay.io/biocontainers/minimap2:2.17--h5bf99c6_4'
     shell:
@@ -55,7 +57,7 @@ rule get_SJs_from_gtf:
     params:
         outdir = OUTDIR
     output:
-        splicejns = OUTDIR / "spliceJns.txt"
+        splicejns = OUTDIR + "/spliceJns.txt"
     threads: 1
     singularity:
         "docker://biocontainers/transcriptclean:v2.0.2_cv1"


### PR DESCRIPTION
I believe input and output file path strings must be concatenated as python strings.
Memory should be also set, per job, just like threads. You should take case these runtime attributes are passed when calling snakemake